### PR TITLE
MavTLog: Skip a parsed message of type None to prevent Attribute Error

### DIFF
--- a/pymavlog/core.py
+++ b/pymavlog/core.py
@@ -353,6 +353,8 @@ class MavTLog(MavLogBase):
         self._types = []
         for name, msg_id in self._mlog.name_to_id.items():
             msg = self._mlog.messages.get(name)
+            if msg is None:
+                continue
             msg_not_in_types = (types is not None) and (name not in types)
             ignore_type = (name in self._messages_ignore) or msg_not_in_types
             if ignore_type:


### PR DESCRIPTION
While parsing tlogs using MavTLog, the error "AttributeError: 'NoneType' object has no attribute 'fieldtypes'" may be encountered in case of a few logs (see issue #36). This prevents further messages from being parsed.

I am not sure about the cause of this issue, it may have happened during log generation but might not be linked to the loss of any particular message. Anyway, we should be parsing as many messages from the tlog as possible, so I have added a continue statement in the __set_parsed_data() function if we encounter a message of NoneType.